### PR TITLE
variable_id aggregation in CORDEX-CMIP6 catalog (intake)

### DIFF
--- a/CORDEX-CMIP6.json
+++ b/CORDEX-CMIP6.json
@@ -60,7 +60,6 @@
       "source_id",
       "version_realization",
       "frequency",
-      "variable_id",
       "version"
     ],
     "aggregations": [


### PR DESCRIPTION
This solves #50

By not grouping per variable_id aggregation can be done - currently the variable_id aggregation is ignored