### PR TITLE
Include sftlf as FWI study requirement

### DIFF
--- a/code/variable_availability.py
+++ b/code/variable_availability.py
@@ -4,19 +4,22 @@ import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
 import seaborn as sns
-import sys
 from icecream import ic
+
 
 def get_studies(dreq):
     studies = set()
     for priorities in dreq["priority"].dropna():
         for priority in priorities.split():
             studies.add(priority.strip())
-    return(sorted(list(studies)))
+    return sorted(list(studies))
+
 
 def plot_availability(study, dreq, catalog, outname="availability.png"):
     dreq_study = dreq.query("priority.str.contains(@study)")
-    dreq_study = dreq_study[["out_name", "frequency"]].rename(columns={"out_name": "variable_id"})
+    dreq_study = dreq_study[["out_name", "frequency"]].rename(
+        columns={"out_name": "variable_id"}
+    )
     #
     #  Plot variable availability as heatmap
     #
@@ -61,6 +64,7 @@ def plot_availability(study, dreq, catalog, outname="availability.png"):
     plt.savefig(outname, bbox_inches="tight")
     plt.close()
 
+
 if __name__ == "__main__":
     url = "dreq_EUR_joint_evaluation.csv"
     dreq = pd.read_csv(url)
@@ -71,10 +75,9 @@ if __name__ == "__main__":
     for study in get_studies(dreq):
         plot_availability(study, dreq, catalog)
         plot_path = f"plots/variable_availability__{study}.png"
-        plot_availability(study, dreq, catalog, outname = plot_path)
+        plot_availability(study, dreq, catalog, outname=plot_path)
         md_lines.append(f"## {study}")
         md_lines.append(f"![{study}]({plot_path})\n")
 
     with open("variable_availability.md", "w") as md_file:
         md_file.write("\n".join(md_lines))
-

--- a/dreq_EUR_joint_evaluation.csv
+++ b/dreq_EUR_joint_evaluation.csv
@@ -46,7 +46,7 @@ sfcWind,day,m s-1,Near-Surface Wind Speed,wind_speed,area: time: mean,HeatStress
 sfcWind,mon,m s-1,Near-Surface Wind Speed,wind_speed,area: time: mean,Trends,
 sfcWindmax,day,m s-1,Daily Maximum Near-Surface Wind Speed,wind_speed,area: mean time: maximum,FWI,Maximum from all integrated time steps per day
 sftlaf,fx,%,Percentage of the Grid Cell Occupied by Lake,area_fraction,area: mean where fresh_free_water,Overview,not in CMIP or in CF
-sftlf,fx,%,Percentage of the Grid Cell Occupied by Land,land_area_fraction,area: mean,Overview WaterBudget,
+sftlf,fx,%,Percentage of the Grid Cell Occupied by Land,land_area_fraction,area: mean,Overview WaterBudget FWI,
 sfturf,fx,%,Percentage of the Grid Cell Occupied by Urban Area,area_fraction,area: mean where urban,Overview,not in CMIP or in CF
 snc,day,%,Snow Area Percentage,surface_snow_area_fraction,area: time: mean,Snow,
 snc,mon,%,Snow Area Percentage,surface_snow_area_fraction,area: time: mean,Snow WaterBudget,


### PR DESCRIPTION
Landmask is required for FWI calculation in order to exclude sea and other large water bodies. Two main reasons:
1. computational efficiency (skipping non-relevant water pixels)
2. avoidance of potential errors in post-processing (e.g., avoiding spurious data in subsequent regridding/interpolation)