### PR TITLE
add climateservicesprio2 to sfcWind

### DIFF
--- a/dreq_EUR_joint_evaluation.csv
+++ b/dreq_EUR_joint_evaluation.csv
@@ -42,7 +42,7 @@ rsdscs,mon,W m-2,Surface Downwelling Clear-Sky Shortwave Radiation,surface_downw
 rsut,mon,W m-2,TOA Outgoing Shortwave Radiation,toa_outgoing_shortwave_flux,area: time: mean,Trends,
 rsutcs,mon,W m-2,TOA Outgoing Clear-Sky Shortwave Radiation,toa_outgoing_shortwave_flux_assuming_clear_sky,area: time: mean,Trends,
 sfcWind,1hr,m s-1,Near-Surface Wind Speed,wind_speed,area: mean time: point,FWI WindEnergy,FWI will only use 12:00 UTC output
-sfcWind,day,m s-1,Near-Surface Wind Speed,wind_speed,area: time: mean,HeatStress WindEnergy,
+sfcWind,day,m s-1,Near-Surface Wind Speed,wind_speed,area: time: mean,ClimateServicesPrio2 HeatStress WindEnergy,
 sfcWind,mon,m s-1,Near-Surface Wind Speed,wind_speed,area: time: mean,Trends,
 sfcWindmax,day,m s-1,Daily Maximum Near-Surface Wind Speed,wind_speed,area: mean time: maximum,FWI,Maximum from all integrated time steps per day
 sftlaf,fx,%,Percentage of the Grid Cell Occupied by Lake,area_fraction,area: mean where fresh_free_water,Overview,not in CMIP or in CF


### PR DESCRIPTION
From L. Corre:
> Would it please be possible to add a daily variable to the list of variables requested on the JSC data server for climate service purposes?
> Indeed, we have realized a flaw in our bias correction chain: we estimate sfcwind from uas and vas while the sfcwind variable is available as output from EURO-CORDEX projections.
> So, would it please be possible to request daily sfcWind for historical and ssp370 runs?

The request was added in this PR. No major problem since the variable was already requested by other studies